### PR TITLE
Occasional nav postition bug fix

### DIFF
--- a/color-picker-challenge/scripts/script.js
+++ b/color-picker-challenge/scripts/script.js
@@ -25,6 +25,11 @@ $(document).ready(function(){
       scroll();
     }
   });
+
+  $("aside img").on("load",function(){
+    navOffset = navEl.offset();
+    navTop = navOffset.top;
+  });
 });
 
 function navigate(hash){


### PR DESCRIPTION
Sometimes when you scroll the page, a gap remains where the activity image used to be in the side-bar...

![image](https://cloud.githubusercontent.com/assets/25212/16603187/0b66ace2-42cf-11e6-8096-8a8edbaba4a3.png)

This change fixes that problem.